### PR TITLE
Update goviolin image tag to ziadmmh/goviolin:v0.0.2

### DIFF
--- a/kubernetes/goviolin/live/live.yaml
+++ b/kubernetes/goviolin/live/live.yaml
@@ -33,7 +33,7 @@ spec:
         app: goviolin
     spec:
       containers:
-      - image: ziadmmh/goviolin:latest
+      - image: ziadmmh/goviolin:v0.0.1
         name: goviolin
         ports:
         - containerPort: 8080


### PR DESCRIPTION
This PR updates the goviolin image tag to ziadmmh/goviolin:v0.0.2.